### PR TITLE
feat: generate keypair and add to .env if one doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 src/temp
 dist
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@solana-developers/node-helpers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/node-helpers",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@digitak/esrun": "^3.2.24",
         "bs58": "^5.0.0",
+        "dotenv": "^16.3.1",
         "prettier": "^3.0.3",
         "typescript": "^5.2.2"
       },
@@ -890,6 +891,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/es6-promise": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@digitak/esrun": "^3.2.24",
     "bs58": "^5.0.0",
+    "dotenv": "^16.3.1",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Keypair } from "@solana/web3.js";
 import base58 from "bs58";
-import fs from "fs";
 import path from "path";
 import { readFile } from "fs/promises";
+import { appendFileSync } from "node:fs";
 const log = console.log;
 
 // Default value from Solana CLI
@@ -46,13 +46,7 @@ export const getKeypairFromFile = async (filepath?: string) => {
 export const getKeypairFromEnvironment = (variableName: string) => {
   const secretKeyString = process.env[variableName];
   if (!secretKeyString) {
-    // Generate a new keypair if one doesn't exist and add it to a `.env` file
-    const keypair = Keypair.generate();
-    fs.appendFileSync(
-      ".env",
-      `\n${variableName}=${JSON.stringify(Array.from(keypair.secretKey))}`,
-    );
-    return keypair;
+    throw new Error(`Please set '${variableName}' in environment.`);
   }
 
   // Try the shorter base58 format first
@@ -78,4 +72,18 @@ export const getKeypairFromEnvironment = (variableName: string) => {
     );
   }
   return Keypair.fromSecretKey(decodedSecretKey);
+};
+
+export const addKeypairToEnvironment = (variableName: string) => {
+  const secretKeyString = process.env[variableName];
+  if (!secretKeyString) {
+    // Generate a new keypair if one doesn't exist and add it to a `.env` file
+    const keypair = Keypair.generate();
+    appendFileSync(
+      ".env",
+      `\n${variableName}=${JSON.stringify(Array.from(keypair.secretKey))}`,
+    );
+  } else {
+    throw new Error(`'${variableName}' already exists in environment.`);
+  }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Keypair } from "@solana/web3.js";
-import { readFile } from "fs/promises";
 import base58 from "bs58";
+import fs from "fs";
 import path from "path";
+import { readFile } from "fs/promises";
 const log = console.log;
 
 // Default value from Solana CLI
@@ -45,7 +46,13 @@ export const getKeypairFromFile = async (filepath?: string) => {
 export const getKeypairFromEnvironment = (variableName: string) => {
   const secretKeyString = process.env[variableName];
   if (!secretKeyString) {
-    throw new Error(`Please set '${variableName}' in environment.`);
+    // Generate a new keypair if one doesn't exist and add it to a `.env` file
+    const keypair = Keypair.generate();
+    fs.appendFileSync(
+      ".env",
+      `\n${variableName}=${JSON.stringify(Array.from(keypair.secretKey))}`,
+    );
+    return keypair;
   }
 
   // Try the shorter base58 format first


### PR DESCRIPTION
Update `getKeypairFromEnvironment` to generate a new keypair and write it to a `.env` file if one does not already exist with the provided `variableName`.