### PR TITLE
fix: fix failing addKeypairToEnvFile test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana-developers/node-helpers",
-  "version": "1.0.4",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/node-helpers",
-      "version": "1.0.4",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@digitak/esrun": "^3.2.24",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,9 +104,9 @@ describe("addKeypairToEnvFile", () => {
   });
 
   test("generates new keypair and writes to env if variable doesn't exist", async () => {
-    addKeypairToEnvFile(testKeypair, "TEMP_KEYPAIR");
+    await addKeypairToEnvFile(testKeypair, "TEMP_KEYPAIR");
 
-    // Now reload the environemnt and check it matches our test keypair
+    // Now reload the environment and check it matches our test keypair
     dotenv.config();
 
     // Get the secret from the .env file


### PR DESCRIPTION
- Fix failing test by awaiting `addKeypairToEnvFile` before reloading to assert
- Bonus: aligns package-lock with `main`

![image](https://github.com/solana-developers/node-helpers/assets/11299576/3b94b154-71a9-4c82-983e-afe3b7c2b01c)
